### PR TITLE
Update linker script to avoid .vectors removal

### DIFF
--- a/lpc1313.dld
+++ b/lpc1313.dld
@@ -15,7 +15,7 @@ SECTIONS {
 
 	vectors :
 	{
-		*(.vectors)
+		KEEP(*(.vectors))
 	} >flash
 
 	.text :


### PR DESCRIPTION
With gcc remove unused section  ("-Xlinker --gc-sections"),  .vectors is its assume as unused (Which is ofc, wrong assumption as its vector interrupt table).

KEEP directive avoid .vectors removal.